### PR TITLE
fix the broken link on the homepage of picolabs.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ published: true
               <nav>
                 <ul class="nav masthead-nav">
                   <li class="active"><a href="#">Home</a></li>
-                  <li class="active"><a href="http://devtools.picolab.io">Developer Tools</a></li>
+                  <li class="active"><a href="http://devtools.picolabs.io">Developer Tools</a></li>
                   <li><a href="https://github.com/Picolab/">Github</a></li>
                   <!-- <li><a href="#">Contact</a></li> -->
                 </ul>


### PR DESCRIPTION
@windley there is a broken link to the devtools on the homepage. Just added an 's' so the link isn't broken anymore. :link: :white_check_mark: 

This requests a pull to the gh-pages branch, as opposed to incorrectly requesting a pull to the master branch as in #1.
